### PR TITLE
feat: render stock information in transactions form

### DIFF
--- a/app/controllers/stocks_details_controller.rb
+++ b/app/controllers/stocks_details_controller.rb
@@ -2,10 +2,14 @@ class StocksDetailsController < StocksController
   def show
     @stock_chart = format_chart_data(@client.chart(params[:symbol], '1y', chart_close_only: true))
     @stock = fetch_stock(params[:symbol])
+    @transaction = Transaction.new(transaction_type: params[:transaction_type])
 
-    render turbo_stream: 
+    render turbo_stream: [
       turbo_stream.update('details', 
                           partial: 'stocks_details/info', 
-                          locals: { details: @stock, chart_data: @stock_chart })
+                          locals: { details: @stock, chart_data: @stock_chart }),
+      turbo_stream.update('transactions_form',
+                          partial: 'transactions/form',
+                          locals: { stock: @stock })]
   end
 end

--- a/app/views/stocks_details/_info.html.erb
+++ b/app/views/stocks_details/_info.html.erb
@@ -1,6 +1,4 @@
-<% if details.nil? || details.empty? %>
-  <p class='text-sm text-center text-muted-foreground font-bold mt-4'>No stock selected</p>
-<% else %>
+<% if details %>
   <%= line_chart chart_data,
     id: 'stock-chart',
     xtitle: 'Date',
@@ -8,5 +6,7 @@
     discrete: true,
     points: false
   %>
-  <%= details %>
+<%= details %>
+<% else %>
+  <p class='text-sm text-center text-muted-foreground font-bold mt-4'>No stock selected</p>
 <% end %> 

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,20 +1,30 @@
-<%= form_with model: transaction do |form| %>
-  <div class="flex flex-col justify-center p-4">
+<% if @transaction %>
+  <%= form_with model: @transaction do |form| %>
+    <div class="flex flex-col justify-center p-4">
 
-    <%= form.label :symbol, "Symbol" %>
-    <%= form.text_field :symbol %>
+      <%= form.label :symbol, "Symbol" %>
+      <%= form.text_field :symbol %>
 
-    <%= form.label :price, "Price" %>
-    <%= form.text_field :price %>
+      <%# price can be rendered through @stock %>
+      <%# issue: the user should not be able to change the price, so either render a span or a disabled text field %>
+      <%= form.label :price, "Price" %>
+      <%= form.text_field :price %>
 
-    <%= form.label :currency, "Currency" %>
-    <%= form.text_field :currency %>
+      <%# issue: no need to display currency since the default is USD for now %>
+      <%= form.label :currency, "Currency" %>
+      <%= form.text_field :currency %>
 
-    <%= form.label :quantity, "Quantity" %>
-    <%= form.text_field :quantity %>
+      <%= form.label :quantity, "Quantity" %>
+      <%= form.text_field :quantity %>
 
-    <%= form.hidden_field :transaction_type, class: "form-control" %>
+      <%= form.hidden_field :transaction_type, class: "form-control" %>
 
-    <%= form.submit transaction.transaction_type.capitalize, class: "p-4 cursor-pointer button button-primary" %>
-  </div>
+      <%# issue: rendering 'Buy' or 'Sell' conditionally won't work, since this partial is now being rendered by the stocks_details controller. It can work if you pass in params[:transaction_type] in the stocks_search/_form %>
+      <%# form.submit @transaction.transaction_type.capitalize, class: "p-4 cursor-pointer button button-primary" %>
+      <%= form.submit 'Buy' %>
+    </div>
+  <% end %>
 <% end %>
+
+<%# note: this is how to render the stocks information %>
+<%= @stock %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,9 +1,11 @@
 <div class='h-full w-full flex items-center justify-center'>
   <div class="flex flex-col lg:flex-row items-center lg:items-start w-full gap-4">
     <%= render_card class: 'h-fit w-full max-w-xs p-6' do %>
-      <%= render 'stocks_search/form' %>
+        <%= render 'stocks_search/form' %>
       <%= render_separator class: 'my-6' %>
-      <%= render "form", transaction: @transaction, items: @stocks %>
+      <turbo-frame id="transactions_form">
+        <%= render "form", locals: { transaction: @transaction } %>
+      </turbo-frame>
     <% end %>
 
     <div class='flex-1 w-full'>


### PR DESCRIPTION
`@stocks` is now accessible from the transactions form. When the user selects a symbol from the search component in the new transaction page, the form updates (via turbo stream) and the selected stock information (i.e. last price) can be rendered.