### PR TITLE
Refactoring authentication

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -2,7 +2,7 @@
 
 class Admin::SessionsController < Devise::SessionsController
   def create
-    if current_user.role != 'admin'
+    if current_user && current_user.role && current_user.role != 'admin'
       sign_out current_user
       redirect_to new_user_session_path
     else

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Admin::SessionsController < Devise::SessionsController
+  def create
+    if current_user.role != 'admin'
+      sign_out current_user
+      redirect_to new_user_session_path
+    else
+      super
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,8 +2,7 @@
 
 class Users::SessionsController < Devise::SessionsController
   def create
-    logger.debug current_user.role
-    if current_user.role == 'admin'
+    if current_user && current_user.role && current_user.role == 'admin'
       sign_out current_user
       redirect_to admin_sign_in_path
     else

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,27 +1,13 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
-
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
+  def create
+    logger.debug current_user.role
+    if current_user.role == 'admin'
+      sign_out current_user
+      redirect_to admin_sign_in_path
+    else
+      super
+    end
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,8 @@
 <%= render 'devise/shared/auth_head' %>
 
-<%= render_form_for(resource, url: session_path(resource_name), class: "flex flex-col gap-4") do |f| %>
+<% form_url = (request.path == admin_sign_in_path) ? admin_sign_in_path(resource) : session_path(resource_name) %>
+
+<%= render_form_for(resource, url: form_url, method: :post, class: "flex flex-col gap-4") do |f| %>
   <%= f.label :email %>
   <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       <nav class="container mx-auto flex items-center justify-between p-4 lg:px-12" aria-label="Global">
         <div class="flex flex-1 gap-1 items-center">
           <%= render 'components/navbar/logo' %>
-          <span class="font-semibold text-xl text-gray-800">Finance</span>
+          <span class="font-semibold text-xl text-secondary">Finance</span>
         </div>
         <% if current_user.present? && current_user.role == 'admin' %>
           <%= render 'components/navbar/admin' %>

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -12,7 +12,11 @@
 
   <body class="h-full max-h-screen bg-background text-foreground font-sans text-sm">
     <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
-      <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="sm:mx-auto sm:w-full sm:max-w-md flex flex-col items-center justify-center gap-8 text-center">
+        <div class="flex flex-1 gap-1 items-center">
+          <%= render 'components/navbar/logo' %>
+          <span class="font-semibold text-xl text-secondary">Finance</span>
+        </div>
         <%= yield(:auth_header) if content_for?(:auth_header) %>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,14 @@
 Rails.application.routes.draw do
   root 'stocks#index'
-  devise_for :users
+
+  devise_scope :user do
+    get 'admin/sign_in', to: 'admin/sessions#new'
+    post 'admin/sign_in', to: 'admin/sessions#create'
+  end
+
+  devise_for :users, controllers: {
+    sessions: 'users/sessions'
+  }
 
   resources :admins, only: [:index]
   namespace :admin do


### PR DESCRIPTION
### Changelog
- New auth route /admin/sign_in
- Admins can now only sign in from the admin sign in route
- Fix uncentered auth header
- Add logo to auth pages

### Problem
Users have a share a single model, where admins and standard users are delineated based on a role (enum). Via Devise, users share authentication controllers where admins and standard users sign in from the same route.

### Solution
Create a new route and controller, which extends from the Devise Sessions Controller. Handle the behaviors of the users/sessions controller and admins/sessions controller to only accept users with the role _standard_ and _admin_ respectively. In the views, render the form urls conditionally based on the request path.