### PR TITLE
Resolve Issue #18: unapproved users should not be able to login

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,11 +2,18 @@
 
 class Users::SessionsController < Devise::SessionsController
   def create
-    if current_user && current_user.role && current_user.role == 'admin'
-      sign_out current_user
-      redirect_to admin_sign_in_path
-    else
-      super
+    if current_user
+      if current_user.role == 'admin'
+        sign_out current_user
+        redirect_to admin_sign_in_path
+      elsif !current_user.approved
+        sign_out current_user
+        
+        flash[:alert] = "Your account is pending admin approval, please wait before signing in."
+        redirect_to new_user_session_path
+      else
+        super
+      end
     end
   end
 end

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -11,6 +11,16 @@
   </head>
 
   <body class="h-full max-h-screen bg-background text-foreground font-sans text-sm">
+    <div id="toast">
+      <% if notice %>
+        <%= render_toast id: "default_toast", description: notice %>
+      <% end %>
+
+      <% if alert %>
+        <%= render_toast description: alert, id: "alert_toast", variant: :destructive %>
+      <% end %>
+    </div>
+
     <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div class="sm:mx-auto sm:w-full sm:max-w-md flex flex-col items-center justify-center gap-8 text-center">
         <div class="flex flex-1 gap-1 items-center">


### PR DESCRIPTION
### Changelog

- Unapproved users will not be redirected to `users/sign_in` when attempting to log in
- An alert toast will be rendered to indicate the authentication error to the user