### PR TITLE
fix: error when buying a new stock

### DIFF
--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -1,10 +1,12 @@
 class Stock < ApplicationRecord
   belongs_to :user
 
-  validates :symbol, presence: true, uniqueness: true
+  validates :symbol, presence: true
 
   def self.find_or_create_stock(user, transaction)
-    user.stocks.find_or_create_by(symbol: transaction.symbol, currency: transaction.currency)
+    stock = user.stocks.find_or_create_by(symbol: transaction.symbol, currency: transaction.currency)
+    raise StandardError, "Failed to find or create stock." unless stock.persisted?
+    stock
   end
 
   def self.update_stock(stock, transaction)

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -27,6 +27,7 @@
 
             <div>
               <%= form.hidden_field :transaction_type, value: transaction_type, class: "form-control" %>
+              <%= form.hidden_field :currency, value: 'USD' %>
               <%= form.submit transaction_type.capitalize, class: "p-4 cursor-pointer button button-primary" %>
             </div>  
           </div>


### PR DESCRIPTION
### Problem
Buying a new stock caused an error `Could not find stock without an id`

### Issue
The symbol uniqueness validation in the stock model caused the `find_or_create_stock` method to fail

### Solution
Remove the _uniqueness_ validation, which was checking the uniquess for all stocks, instead of the user's stocks only